### PR TITLE
Change to a 5 min delay for boiler off condition

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -95,8 +95,8 @@
     to: 'off'
     for:
       hours: 0
-      minutes: 0
-      seconds: 5
+      minutes: 5
+      seconds: 0
   - platform: state
     entity_id:
     - binary_sensor.livingroom_trv_temp_switch_on
@@ -104,8 +104,8 @@
     to: 'off'
     for:
       hours: 0
-      minutes: 0
-      seconds: 5
+      minutes: 5
+      seconds: 0
   - platform: state
     entity_id:
     - binary_sensor.bedroom_trv_temp_switch_on
@@ -113,8 +113,8 @@
     to: 'off'
     for:
       hours: 0
-      minutes: 0
-      seconds: 5
+      minutes: 5
+      seconds: 0
   - platform: state
     entity_id:
     - binary_sensor.spare_room_1_trv_temp_switch_on
@@ -122,8 +122,8 @@
     to: 'off'
     for:
       hours: 0
-      minutes: 0
-      seconds: 5
+      minutes: 5
+      seconds: 0
   condition:
   - condition: and
     conditions:


### PR DESCRIPTION
This was changed by requiring the given binary sensor to be off for 5 minutes. Used to reduce risk of switching on/off too quickly