### PR TITLE
Make pause_all switch off boiler

### DIFF
--- a/automations.yaml
+++ b/automations.yaml
@@ -525,6 +525,8 @@
   action:
   - service: homeassistant.turn_off
     entity_id: group.thermostats
+  - service: homeassistant.turn_off
+    entity_id: climate.boiler_thermostat_thermostat
   - delay: '{{(states(''input_number.heating_pause_hrs_all'')|int) * 3600}}'
   - service: homeassistant.turn_on
     entity_id: group.thermostats


### PR DESCRIPTION
The boiler on state at the end of the pause is handled by boiler_on_binary_sensor